### PR TITLE
feat: allow replacing cors-anywhere with your own proxy using env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # misc
 .idea
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "url": "https://github.com/alexandrtovmach/react-twitter-login"
   },
   "dependencies": {
-    "crypto-js": "^3.1.9-1"
+    "crypto-js": "^3.1.9-1",
+    "dotenv-webpack": "^2.0.0"
   }
 }

--- a/src/services/oauth1.ts
+++ b/src/services/oauth1.ts
@@ -1,5 +1,8 @@
 import { requestTokenSignature, accessTokenSignature } from "./signature";
 
+const proxyUrl =
+  process.env.PROXY_URL || "https://cors-anywhere.herokuapp.com/";
+
 interface RequestTokenResponse {
   oauth_token: string;
   oauth_token_secret: string;
@@ -32,7 +35,7 @@ export const obtainOauthRequestToken = async ({
     consumerKey,
     consumerSecret
   });
-  const res = await fetch(`https://cors-anywhere.herokuapp.com/${apiUrl}`, {
+  const res = await fetch(`${proxyUrl}${apiUrl}`, {
     method,
     headers: {
       Authorization: `OAuth ${oauthSignature}`
@@ -65,7 +68,7 @@ export const obtainOauthAccessToken = async ({
     oauthToken,
     oauthVerifier
   });
-  const res = await fetch(`https://cors-anywhere.herokuapp.com/${apiUrl}`, {
+  const res = await fetch(`${proxyUrl}${apiUrl}`, {
     method,
     headers: {
       Authorization: `OAuth ${oauthSignature}`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const Dotenv = require('dotenv-webpack');
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const htmlWebpackPlugin = new HtmlWebpackPlugin({
   template: path.join(__dirname, "examples/src/index.html"),
@@ -47,7 +48,7 @@ module.exports = {
       },
     ]
   },
-  plugins: [htmlWebpackPlugin],
+  plugins: [htmlWebpackPlugin, new Dotenv()],
   resolve: {
     extensions: [".js", ".jsx"]
   },


### PR DESCRIPTION
cors-anywhere heroku is not a fantastic place to always proxy through to get to the twitter api. While it makes sense for demos or for testing, pulling in a PROXY_URL from the environment variables makes a lot more sense to avoid sending requests to third parties.